### PR TITLE
v1.1.0 Add existing list with options

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,8 +31,8 @@ android {
         applicationId = "com.heyzeusv.yourlists"
         minSdk = 24
         targetSdk = 34
-        versionCode = 2
-        versionName = "1.0.1"
+        versionCode = 3
+        versionName = "1.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
@@ -279,6 +279,7 @@ fun AddListPage(
     itemLists: List<ItemListWithItems>,
     itemListOnClick: (ItemListWithItems) -> Unit,
 ) {
+    // TODO: Add 'warning' about limitation of list not having parent and child list at same time
     val listState = rememberLazyListState()
 
     LazyColumn(

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
@@ -118,6 +118,7 @@ fun AddScreen(
 
     var showBottomSheet by remember { mutableStateOf(false) }
     var selectedDefaultItem by remember { mutableStateOf(DefaultItem()) }
+    var selectedItemList by remember { mutableStateOf(ItemListWithItems()) }
 
     BackHandler(enabled = showBottomSheet) {
         showBottomSheet = false
@@ -147,7 +148,13 @@ fun AddScreen(
                     )
                 }
                 1 -> {
-                    AddListPage(itemLists = itemLists)
+                    AddListPage(
+                        itemLists = itemLists,
+                        itemListOnClick = {
+                            selectedItemList = it
+                            showBottomSheet = true
+                        }
+                    )
                 }
             }
         }
@@ -270,6 +277,7 @@ fun AddItemPage(
 @Composable
 fun AddListPage(
     itemLists: List<ItemListWithItems>,
+    itemListOnClick: (ItemListWithItems) -> Unit,
 ) {
     val listState = rememberLazyListState()
 
@@ -281,7 +289,7 @@ fun AddListPage(
         items(itemLists) {
             ListInfo(
                 itemList = it,
-                itemListOnClick = { _, _ -> },
+                itemListOnClick = itemListOnClick,
                 displayOptions = false,
             )
         }
@@ -415,7 +423,10 @@ private fun AddItemPagePreview() {
 private fun AddListPagePreview() {
     PreviewUtil.run {
         Preview {
-            AddListPage(itemLists = itemLists)
+            AddListPage(
+                itemLists = itemLists,
+                itemListOnClick = { }
+            )
         }
     }
 }

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
@@ -201,7 +201,7 @@ fun AddItemPage(
     Column(
         modifier = Modifier
             .padding(all = dRes(R.dimen.as_padding_all))
-            .fillMaxSize()
+            .fillMaxSize(),
     ) {
         TextField(
             value = defaultItemQuery ,
@@ -279,20 +279,32 @@ fun AddListPage(
     itemLists: List<ItemListWithItems>,
     itemListOnClick: (ItemListWithItems) -> Unit,
 ) {
-    // TODO: Add 'warning' about limitation of list not having parent and child list at same time
     val listState = rememberLazyListState()
 
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        state = listState,
-        verticalArrangement = Arrangement.spacedBy(dRes(R.dimen.as_list_spacedBy)),
+    Column(
+        modifier = Modifier
+            .padding(all = dRes(R.dimen.as_padding_all))
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(dRes(R.dimen.as_list_spacedBy))
     ) {
-        items(itemLists) {
-            ListInfo(
-                itemList = it,
-                itemListOnClick = itemListOnClick,
-                displayOptions = false,
-            )
+        Text(
+            text = sRes(R.string.as_list_warning),
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleSmall
+        )
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            state = listState,
+            verticalArrangement = Arrangement.spacedBy(dRes(R.dimen.as_list_spacedBy)),
+        ) {
+            items(itemLists) {
+                ListInfo(
+                    itemList = it,
+                    itemListOnClick = itemListOnClick,
+                    displayOptions = false,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
@@ -44,17 +44,18 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.heyzeusv.yourlists.R
 import com.heyzeusv.yourlists.database.models.Category
 import com.heyzeusv.yourlists.database.models.DefaultItem
+import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.util.EditItemBottomSheetContent
 import com.heyzeusv.yourlists.util.AddDestination
 import com.heyzeusv.yourlists.util.BottomSheet
 import com.heyzeusv.yourlists.util.FabState
 import com.heyzeusv.yourlists.util.ItemInfo
+import com.heyzeusv.yourlists.util.ListInfo
 import com.heyzeusv.yourlists.util.PreviewUtil
 import com.heyzeusv.yourlists.util.TopAppBarState
 import com.heyzeusv.yourlists.util.dRes
@@ -73,7 +74,7 @@ fun AddScreen(
     val topAppBarTitle = sRes(AddDestination.title)
     val defaultItemQuery by addVM.defaultItemQuery.collectAsStateWithLifecycle()
     val defaultItems by addVM.defaultItems.collectAsStateWithLifecycle(initialValue = emptyList())
-//    val itemLists by addVM.itemLists.collectAsStateWithLifecycle()
+    val itemLists by addVM.itemLists.collectAsStateWithLifecycle()
     val categories by addVM.categories.collectAsStateWithLifecycle()
 
     LaunchedEffect(key1 = Unit) {
@@ -96,7 +97,7 @@ fun AddScreen(
         saveAndAddOnClick = addVM::saveDefaultItemAndAddItem,
         addToListOnClick = addVM::addItem,
         deleteDefaultItemOnClick = addVM::deleteDefaultItem,
-//        itemLists = itemLists,
+        itemLists = itemLists,
     )
 }
 
@@ -110,7 +111,7 @@ fun AddScreen(
     saveAndAddOnClick: (DefaultItem) -> Unit,
     addToListOnClick: (DefaultItem) -> Unit,
     deleteDefaultItemOnClick: (DefaultItem) -> Unit,
-//    itemLists: List<ItemListWithItems>,
+    itemLists: List<ItemListWithItems>,
 ) {
     val pagerState = rememberPagerState(pageCount = { 2 })
     val coroutineScope = rememberCoroutineScope()
@@ -144,6 +145,9 @@ fun AddScreen(
                         updateSelectedDefaultItem = { selectedDefaultItem = it },
                         updateShowBottomSheet = { showBottomSheet = it },
                     )
+                }
+                1 -> {
+                    AddListPage(itemLists = itemLists)
                 }
             }
         }
@@ -247,7 +251,7 @@ fun AddItemPage(
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             state = listState,
-            verticalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(dRes(R.dimen.as_list_spacedBy)),
         ) {
             items(defaultItems) {
                 ItemInfo(
@@ -259,6 +263,27 @@ fun AddItemPage(
                     },
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun AddListPage(
+    itemLists: List<ItemListWithItems>,
+) {
+    val listState = rememberLazyListState()
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        state = listState,
+        verticalArrangement = Arrangement.spacedBy(dRes(R.dimen.as_list_spacedBy)),
+    ) {
+        items(itemLists) {
+            ListInfo(
+                itemList = it,
+                itemListOnClick = { _, _ -> },
+                displayOptions = false,
+            )
         }
     }
 }
@@ -341,7 +366,7 @@ private fun AddScreenPreview() {
                 updateDefaultItemQuery = { },
                 defaultItems = defaultItemList,
                 categories = emptyList(),
-//                itemLists = emptyList(),
+                itemLists = emptyList(),
                 saveAndAddOnClick = { },
                 addToListOnClick = { },
                 deleteDefaultItemOnClick = { },
@@ -360,11 +385,37 @@ private fun AddScreenBlankQueryPreview() {
                 updateDefaultItemQuery = { },
                 defaultItems = defaultItemList,
                 categories = emptyList(),
-//                itemLists = emptyList(),
+                itemLists = emptyList(),
                 saveAndAddOnClick = { },
                 addToListOnClick = { },
                 deleteDefaultItemOnClick = { },
             )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AddItemPagePreview() {
+    PreviewUtil.run {
+        Preview {
+            AddItemPage(
+                defaultItemQuery = "Preview",
+                updateDefaultItemQuery = { },
+                defaultItems = emptyList(),
+                updateSelectedDefaultItem = { },
+                updateShowBottomSheet = { },
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AddListPagePreview() {
+    PreviewUtil.run {
+        Preview {
+            AddListPage(itemLists = itemLists)
         }
     }
 }

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
@@ -26,6 +26,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -33,6 +35,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,6 +61,7 @@ import com.heyzeusv.yourlists.util.dRes
 import com.heyzeusv.yourlists.util.iRes
 import com.heyzeusv.yourlists.util.pRes
 import com.heyzeusv.yourlists.util.sRes
+import kotlinx.coroutines.launch
 
 @Composable
 fun AddScreen(
@@ -109,22 +113,38 @@ fun AddScreen(
 //    itemLists: List<ItemListWithItems>,
 ) {
     val pagerState = rememberPagerState(pageCount = { 2 })
+    val coroutineScope = rememberCoroutineScope()
+
     var showBottomSheet by remember { mutableStateOf(false) }
     var selectedDefaultItem by remember { mutableStateOf(DefaultItem()) }
 
     BackHandler(enabled = showBottomSheet) {
         showBottomSheet = false
     }
-    HorizontalPager(state = pagerState) { page ->
-        when (page) {
-            0 -> {
-                AddItemPage(
-                    defaultItemQuery = defaultItemQuery,
-                    updateDefaultItemQuery = updateDefaultItemQuery,
-                    defaultItems = defaultItems,
-                    updateSelectedDefaultItem = { selectedDefaultItem = it },
-                    updateShowBottomSheet = { showBottomSheet = it }
+    Column {
+        TabRow(
+            selectedTabIndex = pagerState.currentPage,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            AddTabs.entries.forEachIndexed { index, addTabs ->
+                Tab(
+                    selected = index == pagerState.currentPage,
+                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+                    text = { Text(text = sRes(addTabs.nameId)) },
                 )
+            }
+        }
+        HorizontalPager(state = pagerState) { page ->
+            when (page) {
+                0 -> {
+                    AddItemPage(
+                        defaultItemQuery = defaultItemQuery,
+                        updateDefaultItemQuery = updateDefaultItemQuery,
+                        defaultItems = defaultItems,
+                        updateSelectedDefaultItem = { selectedDefaultItem = it },
+                        updateShowBottomSheet = { showBottomSheet = it },
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddListOptions.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddListOptions.kt
@@ -1,0 +1,7 @@
+package com.heyzeusv.yourlists.add
+
+enum class AddListOptions {
+    ALL_AS_UNCHECKED,
+    ALL_AS_IS,
+    ONLY_UNCHECKED,
+}

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddTabs.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddTabs.kt
@@ -1,0 +1,9 @@
+package com.heyzeusv.yourlists.add
+
+import androidx.annotation.StringRes
+import com.heyzeusv.yourlists.R
+
+enum class AddTabs(@StringRes val nameId: Int) {
+    ITEM(R.string.as_item_tab),
+    LIST(R.string.as_list_tab),
+}

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddViewModel.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.heyzeusv.yourlists.database.Repository
 import com.heyzeusv.yourlists.database.models.Category
 import com.heyzeusv.yourlists.database.models.DefaultItem
+import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.util.AddDestination
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -94,5 +95,9 @@ class AddViewModel @Inject constructor(
 
     fun deleteDefaultItem(defaultItem: DefaultItem) {
         viewModelScope.launch { repo.deleteDefaultItems(defaultItem) }
+    }
+
+    fun addListWithOption(itemList: ItemListWithItems, option: AddListOptions) {
+
     }
 }

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddViewModel.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.heyzeusv.yourlists.database.Repository
 import com.heyzeusv.yourlists.database.models.Category
 import com.heyzeusv.yourlists.database.models.DefaultItem
+import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.util.AddDestination
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -48,8 +49,8 @@ class AddViewModel @Inject constructor(
     private val _categories = MutableStateFlow(emptyList<Category>())
     val categories = _categories.asStateFlow()
 
-//    private val _itemLists = MutableStateFlow(emptyList<ItemListWithItems>())
-//    val itemLists = _itemLists.asStateFlow()
+    private val _itemLists = MutableStateFlow(emptyList<ItemListWithItems>())
+    val itemLists = _itemLists.asStateFlow()
 
     init {
 //        getAllItemLists()

--- a/app/src/main/java/com/heyzeusv/yourlists/database/Repository.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/database/Repository.kt
@@ -11,7 +11,7 @@ interface Repository {
     /**
      *  ItemList Queries
      */
-    suspend fun insertItemList(vararg itemLists: ItemList): Long
+    suspend fun insertItemList(vararg itemLists: ItemList)
 
     suspend fun updateItemList(vararg itemLists: ItemList)
 
@@ -28,7 +28,7 @@ interface Repository {
     /**
      *  Item Queries
      */
-    suspend fun insertItems(vararg items: Item): Long
+    suspend fun insertItems(vararg items: Item)
 
     suspend fun updateItems(vararg items: Item)
 
@@ -48,7 +48,7 @@ interface Repository {
     /**
      *  Category Queries
      */
-    suspend fun insertCategories(vararg categories: Category): Long
+    suspend fun insertCategories(vararg categories: Category)
 
     fun getAllCategories(): Flow<List<Category>>
 }

--- a/app/src/main/java/com/heyzeusv/yourlists/database/Repository.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/database/Repository.kt
@@ -19,6 +19,8 @@ interface Repository {
 
     fun getAllItemLists(): Flow<List<ItemListWithItems>>
 
+    fun getAllItemListsWithoutId(id: Long): Flow<List<ItemListWithItems>>
+
     fun getItemListWithId(id: Long): Flow<ItemListWithItems?>
 
     fun getMaxItemListId(): Flow<Long?>

--- a/app/src/main/java/com/heyzeusv/yourlists/database/RepositoryImpl.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/database/RepositoryImpl.kt
@@ -35,6 +35,9 @@ class RepositoryImpl @Inject constructor(
     override fun getAllItemLists(): Flow<List<ItemListWithItems>> =
         itemListDao.getAllItemListsWithItems()
 
+    override fun getAllItemListsWithoutId(id: Long): Flow<List<ItemListWithItems>> =
+        itemListDao.getAllItemListsWithoutId(id)
+
     override fun getItemListWithId(id: Long): Flow<ItemListWithItems?> =
         itemListDao.getItemListWithId(id)
 

--- a/app/src/main/java/com/heyzeusv/yourlists/database/RepositoryImpl.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/database/RepositoryImpl.kt
@@ -23,8 +23,8 @@ class RepositoryImpl @Inject constructor(
     /**
      *  ItemList Queries
      */
-    override suspend fun insertItemList(vararg itemLists: ItemList): Long =
-        withContext(Dispatchers.IO) { itemListDao.insert(*itemLists).first() }
+    override suspend fun insertItemList(vararg itemLists: ItemList) =
+        withContext(Dispatchers.IO) { itemListDao.insert(*itemLists) }
 
     override suspend fun updateItemList(vararg itemLists: ItemList) =
         withContext(Dispatchers.IO) { itemListDao.update(*itemLists) }
@@ -46,8 +46,8 @@ class RepositoryImpl @Inject constructor(
     /**
      *  Item Queries
      */
-    override suspend fun insertItems(vararg items: Item): Long =
-        withContext(Dispatchers.IO) { itemDao.insert(*items).first() }
+    override suspend fun insertItems(vararg items: Item) =
+        withContext(Dispatchers.IO) { itemDao.insert(*items) }
 
     override suspend fun updateItems(vararg items: Item) =
         withContext(Dispatchers.IO) { itemDao.update(*items) }
@@ -73,8 +73,8 @@ class RepositoryImpl @Inject constructor(
     /**
      *  Category Queries
      */
-    override suspend fun insertCategories(vararg categories: Category): Long =
-        withContext(Dispatchers.IO) { categoryDao.insert(*categories).first() }
+    override suspend fun insertCategories(vararg categories: Category) =
+        withContext(Dispatchers.IO) { categoryDao.insert(*categories) }
 
     override fun getAllCategories(): Flow<List<Category>> = categoryDao.getAllCategories()
 }

--- a/app/src/main/java/com/heyzeusv/yourlists/database/dao/BaseDao.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/database/dao/BaseDao.kt
@@ -10,7 +10,7 @@ import androidx.room.Upsert
 @Dao
 interface BaseDao<T> {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insert(vararg entities: T): List<Long>
+    suspend fun insert(vararg entities: T)
 
     @Update
     suspend fun update(vararg entities: T)

--- a/app/src/main/java/com/heyzeusv/yourlists/database/dao/ItemListDao.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/database/dao/ItemListDao.kt
@@ -18,6 +18,12 @@ interface ItemListDao : BaseDao<ItemList> {
     @Transaction
     @Query("SELECT * " +
             "FROM ItemList " +
+            "WHERE itemListId IS NOT (:id)")
+    fun getAllItemListsWithoutId(id: Long): Flow<List<ItemListWithItems>>
+
+    @Transaction
+    @Query("SELECT * " +
+            "FROM ItemList " +
             "WHERE itemListId=(:id)")
     fun getItemListWithId(id: Long): Flow<ItemListWithItems?>
 

--- a/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
@@ -84,7 +84,9 @@ fun OverviewScreen(
     }
     OverviewScreen(
         itemLists = itemLists,
-        itemListOnClick = { id, name -> navController.navigateToItemList(id, name) },
+        itemListOnClick = { itemList ->
+            itemList.itemList.let { navController.navigateToItemList(it.itemListId, it.name) }
+        },
         emptyButtonOnClick = { displayNewListAlertDialog = true },
         showBottomSheet = showBottomSheet,
         updateShowBottomSheet = { showBottomSheet = it },
@@ -109,7 +111,7 @@ fun OverviewScreen(
 @Composable
 fun OverviewScreen(
     itemLists: List<ItemListWithItems>,
-    itemListOnClick: (Long, String) -> Unit,
+    itemListOnClick: (ItemListWithItems) -> Unit,
     emptyButtonOnClick: () -> Unit,
     showBottomSheet: Boolean,
     updateShowBottomSheet: (Boolean) -> Unit,
@@ -249,7 +251,7 @@ private fun OverviewScreenPreview() {
         Preview {
             OverviewScreen(
                 itemLists = itemLists,
-                itemListOnClick = { _, _ -> },
+                itemListOnClick = { },
                 emptyButtonOnClick = { },
                 showBottomSheet = false,
                 updateShowBottomSheet = { },
@@ -268,7 +270,7 @@ private fun OverviewScreenEmptyPreview() {
         Preview {
             OverviewScreen(
                 itemLists = emptyList(),
-                itemListOnClick = { _, _ -> },
+                itemListOnClick = { },
                 emptyButtonOnClick = { },
                 showBottomSheet = false,
                 updateShowBottomSheet = { },

--- a/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
@@ -13,10 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -28,7 +25,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -39,6 +35,7 @@ import com.heyzeusv.yourlists.util.BottomSheet
 import com.heyzeusv.yourlists.util.EmptyList
 import com.heyzeusv.yourlists.util.FabState
 import com.heyzeusv.yourlists.util.InputAlertDialog
+import com.heyzeusv.yourlists.util.ListInfo
 import com.heyzeusv.yourlists.util.OverviewDestination
 import com.heyzeusv.yourlists.util.PreviewUtil
 import com.heyzeusv.yourlists.util.TopAppBarState
@@ -137,6 +134,7 @@ fun OverviewScreen(
                 ListInfo(
                     itemList = it,
                     itemListOnClick = itemListOnClick,
+                    displayOptions = true,
                     optionOnClick = { selected ->
                         selectedItemList = selected
                         updateShowBottomSheet(true)
@@ -183,57 +181,6 @@ fun OverviewScreen(
         },
         onDismiss = { showRenameAlertDialog = null }
     )
-}
-
-@Composable
-fun ListInfo(
-    itemList: ItemListWithItems,
-    itemListOnClick: (Long, String) -> Unit,
-    optionOnClick: (ItemListWithItems) -> Unit,
-) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { itemListOnClick(itemList.itemList.itemListId, itemList.itemList.name) },
-        shape = RoundedCornerShape(dRes(R.dimen.card_radius)),
-    ) {
-        Column(modifier = Modifier.padding(all = dRes(R.dimen.osli_padding_all))) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = itemList.itemList.name,
-                    modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.headlineMedium
-                )
-                Icon(
-                    painter = pRes(R.drawable.icon_options),
-                    contentDescription = sRes(R.string.button_cdesc_options),
-                    modifier = Modifier
-                        .align(Alignment.Top)
-                        .padding(top = dRes(R.dimen.osli_options_padding_top))
-                        .clickable { optionOnClick(itemList) },
-                )
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(dRes(R.dimen.osli_progress_spacedBy)),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                LinearProgressIndicator(
-                    progress = { itemList.progress.first },
-                    modifier = Modifier
-                        .height(dRes(R.dimen.osli_progress_height))
-                        .weight(1f),
-                    trackColor = MaterialTheme.colorScheme.background,
-                    strokeCap = StrokeCap.Round
-                )
-                Text(text = itemList.progress.second)
-            }
-        }
-    }
 }
 
 @Composable
@@ -301,7 +248,7 @@ private fun OverviewScreenPreview() {
     PreviewUtil.run {
         Preview {
             OverviewScreen(
-                itemLists = List(15) { halfCheckedItemList },
+                itemLists = itemLists,
                 itemListOnClick = { _, _ -> },
                 emptyButtonOnClick = { },
                 showBottomSheet = false,
@@ -328,20 +275,6 @@ private fun OverviewScreenEmptyPreview() {
                 optionRenameOnClick = { _, _ -> },
                 optionCopyOnClick = { },
                 optionDeleteOnClick = { },
-            )
-        }
-    }
-}
-
-@Preview
-@Composable
-private fun ListInfoPreview() {
-    PreviewUtil.run {
-        Preview {
-            ListInfo(
-                itemList = halfCheckedItemList,
-                itemListOnClick = { _, _ -> },
-                optionOnClick = { },
             )
         }
     }

--- a/app/src/main/java/com/heyzeusv/yourlists/util/Destination.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/Destination.kt
@@ -70,7 +70,7 @@ object ListDestination: Destination {
 
 object AddDestination: Destination {
     override val route: String = "add"
-    override val title: Int = R.string.as_item_title
+    override val title: Int = R.string.as_title
     override val navIcon: ImageVector = Icons.AutoMirrored.Filled.ArrowBack
     override val navDescription: Int = R.string.navigate_back
     override val actionLeftIcon: ImageVector = Blank

--- a/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
@@ -177,14 +177,14 @@ fun ItemInfo(
 @Composable
 fun ListInfo(
     itemList: ItemListWithItems,
-    itemListOnClick: (Long, String) -> Unit,
+    itemListOnClick: (ItemListWithItems) -> Unit,
     displayOptions: Boolean,
     optionOnClick: (ItemListWithItems) -> Unit = { },
 ) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { itemListOnClick(itemList.itemList.itemListId, itemList.itemList.name) },
+            .clickable { itemListOnClick(itemList) },
         shape = RoundedCornerShape(dRes(R.dimen.card_radius)),
     ) {
         Column(modifier = Modifier.padding(all = dRes(R.dimen.osli_padding_all))) {
@@ -561,7 +561,7 @@ private fun ListInfoPreview() {
         Preview {
             ListInfo(
                 itemList = halfCheckedItemList,
-                itemListOnClick = { _, _ -> },
+                itemListOnClick = { },
                 displayOptions = true,
                 optionOnClick = { },
             )
@@ -576,7 +576,7 @@ private fun ListInfoNoOptionsPreview() {
         Preview {
             ListInfo(
                 itemList = emptyItemList,
-                itemListOnClick = { _, _ -> },
+                itemListOnClick = { },
                 displayOptions = false,
                 optionOnClick = { },
             )

--- a/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -36,6 +37,7 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -51,6 +53,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
@@ -64,6 +67,7 @@ import com.heyzeusv.yourlists.add.FilteredDropDownMenu
 import com.heyzeusv.yourlists.database.models.BaseItem
 import com.heyzeusv.yourlists.database.models.Category
 import com.heyzeusv.yourlists.database.models.Item
+import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.ui.theme.BlackAlpha60
 import java.text.DecimalFormat
 
@@ -165,6 +169,60 @@ fun ItemInfo(
                     maxLines = 2,
                     style = MaterialTheme.typography.bodySmall,
                 )
+            }
+        }
+    }
+}
+
+@Composable
+fun ListInfo(
+    itemList: ItemListWithItems,
+    itemListOnClick: (Long, String) -> Unit,
+    displayOptions: Boolean,
+    optionOnClick: (ItemListWithItems) -> Unit = { },
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { itemListOnClick(itemList.itemList.itemListId, itemList.itemList.name) },
+        shape = RoundedCornerShape(dRes(R.dimen.card_radius)),
+    ) {
+        Column(modifier = Modifier.padding(all = dRes(R.dimen.osli_padding_all))) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = itemList.itemList.name,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.headlineMedium
+                )
+                if (displayOptions) {
+                    Icon(
+                        painter = pRes(R.drawable.icon_options),
+                        contentDescription = sRes(R.string.button_cdesc_options),
+                        modifier = Modifier
+                            .align(Alignment.Top)
+                            .padding(top = dRes(R.dimen.osli_options_padding_top))
+                            .clickable { optionOnClick(itemList) },
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(dRes(R.dimen.osli_progress_spacedBy)),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                LinearProgressIndicator(
+                    progress = { itemList.progress.first },
+                    modifier = Modifier
+                        .height(dRes(R.dimen.osli_progress_height))
+                        .weight(1f),
+                    trackColor = MaterialTheme.colorScheme.background,
+                    strokeCap = StrokeCap.Round
+                )
+                Text(text = itemList.progress.second)
             }
         }
     }
@@ -492,6 +550,36 @@ private fun DefaultItemInfoPreview() {
                     surfaceOnClick = { },
                 )
             }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ListInfoPreview() {
+    PreviewUtil.run {
+        Preview {
+            ListInfo(
+                itemList = halfCheckedItemList,
+                itemListOnClick = { _, _ -> },
+                displayOptions = true,
+                optionOnClick = { },
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ListInfoNoOptionsPreview() {
+    PreviewUtil.run {
+        Preview {
+            ListInfo(
+                itemList = emptyItemList,
+                itemListOnClick = { _, _ -> },
+                displayOptions = false,
+                optionOnClick = { },
+            )
         }
     }
 }

--- a/app/src/main/java/com/heyzeusv/yourlists/util/PreviewUtil.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/PreviewUtil.kt
@@ -45,6 +45,7 @@ object PreviewUtil {
         itemList = ItemList(0L, "Empty List"),
         items = emptyList()
     )
+    val itemLists = List(10) { if (it % 2 == 0) halfCheckedItemList else emptyItemList }
     val defaultItem = DefaultItem(
         itemId = 0L,
         name = "DefaultItem DefaultItem DefaultItem DefaultItem DefaultItem",

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,6 +6,7 @@
     <!-- AddScreen (as) -->
     <dimen name="as_padding_all">16.dp</dimen>
     <dimen name="as_query_padding_bottom">12.dp</dimen>
+    <dimen name="as_list_spacedBy">6.dp</dimen>
     <!-- AddScreen.BottomSheet (asbs) -->
     <dimen name="asbs_vertical_spacedBy">4.dp</dimen>
     <dimen name="asbs_button_padding_horizontal">16.dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,9 @@
     <string name="asbs_save_add">Save as default &amp; add to list</string>
     <string name="asbs_update_add">Update defaults &amp; add to list</string>
     <string name="asbs_delete">Delete defaults</string>
+    <string name="asbs_add_all_unchecked">Add all items as unchecked</string>
+    <string name="asbs_add_all_as_is">Add all items as is</string>
+    <string name="asbs_add_only_uncheck">Add only unchecked items</string>
 
     <!-- InputAlertDialog (iad) -->
     <string name="iad_label">Enter a name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="as_item_query_placeholder">Add Item</string>
     <string name="as_query_clear">Clear query</string>
     <string name="as_add_new">Add %1$s</string>
+    <string name="as_list_warning">Can\'t find a list? You cannot add a list to itself and you cannot add a list that already has a list within it.</string>
     <!-- AddScreen.BottomSheet (asbs) -->
     <string name="asbs_name">Item Name</string>
     <string name="asbs_category">Category</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,8 +11,9 @@
     </string-array>
 
     <!-- AddScreen (as) -->
-    <string name="as_item_title">Add Item</string>
-    <string name="as_list_title">Add List</string>
+    <string name="as_title">Add</string>
+    <string name="as_item_tab">Item</string>
+    <string name="as_list_tab">List</string>
     <string name="as_item_query_placeholder">Add Item</string>
     <string name="as_query_clear">Clear query</string>
     <string name="as_add_new">Add %1$s</string>


### PR DESCRIPTION
Added HorizontalPager to Add Screen where users can pick between adding single items like before or add existing lists with three different options.

1. Add all items as unchecked
2. Add all items as is
3. Add only unchecked items

Fixed a bug where copying an empty list would cause the app to crash due to Repository call expecting a Long to return on Insert queries. Removed the Long return type from Insert queries since it was only used on now removed custom Upsert query.