### PR TITLE
v2.2.0 Overview screen copy list options

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,8 +33,8 @@ android {
         applicationId = "com.heyzeusv.yourlists"
         minSdk = 24
         targetSdk = 34
-        versionCode = 6
-        versionName = "2.1.0"
+        versionCode = 7
+        versionName = "2.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
@@ -47,7 +47,8 @@ import com.heyzeusv.yourlists.database.models.DefaultItem
 import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.util.EditItemBottomSheetContent
 import com.heyzeusv.yourlists.util.AddDestination
-import com.heyzeusv.yourlists.util.ListOptions
+import com.heyzeusv.yourlists.util.ListOptions.Copy
+import com.heyzeusv.yourlists.util.ListOptions.Copy.*
 import com.heyzeusv.yourlists.util.BottomSheet
 import com.heyzeusv.yourlists.util.FabState
 import com.heyzeusv.yourlists.util.ItemInfo
@@ -109,7 +110,7 @@ fun AddScreen(
     addToListOnClick: (DefaultItem) -> Unit,
     deleteDefaultItemOnClick: (DefaultItem) -> Unit,
     itemLists: List<ItemListWithItems>,
-    addListButtonOnClick: (ItemListWithItems, ListOptions) -> Unit,
+    addListButtonOnClick: (Copy) -> Unit,
 ) {
     val pagerState = rememberPagerState(pageCount = { 2 })
     val coroutineScope = rememberCoroutineScope()
@@ -185,8 +186,8 @@ fun AddScreen(
             1 -> {
                 AddListBottomSheetContent(
                     itemList = selectedItemList,
-                    buttonOnClick = { itemList, option ->
-                        addListButtonOnClick(itemList, option)
+                    buttonOnClick = { option ->
+                        addListButtonOnClick(option)
                         showBottomSheet = false
                     }
                 )
@@ -328,7 +329,7 @@ fun AddListPage(
 @Composable
 fun AddListBottomSheetContent(
     itemList: ItemListWithItems,
-    buttonOnClick: (ItemListWithItems, ListOptions) -> Unit,
+    buttonOnClick: (Copy) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -341,14 +342,14 @@ fun AddListBottomSheetContent(
             style = MaterialTheme.typography.headlineMedium
         )
         Button(
-            onClick = { buttonOnClick(itemList, ListOptions.COPY_ALL_AS_UNCHECKED) },
+            onClick = { buttonOnClick(AllAsUnchecked(itemList)) },
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.extraSmall,
         ) {
             Text(text = sRes(R.string.asbs_add_all_unchecked).uppercase())
         }
         Button(
-            onClick = { buttonOnClick(itemList, ListOptions.COPY_ALL_AS_IS) },
+            onClick = { buttonOnClick(AllAsIs(itemList)) },
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.extraSmall,
             colors = ButtonDefaults.filledTonalButtonColors(
@@ -359,7 +360,7 @@ fun AddListBottomSheetContent(
             Text(text = sRes(R.string.asbs_add_all_as_is).uppercase())
         }
         OutlinedButton(
-            onClick = { buttonOnClick(itemList, ListOptions.COPY_ONLY_UNCHECKED) },
+            onClick = { buttonOnClick(OnlyUnchecked(itemList)) },
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.extraSmall,
         ) {
@@ -382,7 +383,7 @@ private fun AddScreenPreview() {
                 addToListOnClick = { },
                 deleteDefaultItemOnClick = { },
                 itemLists = emptyList(),
-                addListButtonOnClick = { _, _ -> },
+                addListButtonOnClick = { _ -> },
             )
         }
     }
@@ -402,7 +403,7 @@ private fun AddScreenBlankQueryPreview() {
                 addToListOnClick = { },
                 deleteDefaultItemOnClick = { },
                 itemLists = emptyList(),
-                addListButtonOnClick = { _, _ -> },
+                addListButtonOnClick = { _ -> },
             )
         }
     }
@@ -445,7 +446,7 @@ private fun AddListBottomSheetPreview() {
             Surface {
                 AddListBottomSheetContent(
                     itemList = halfCheckedItemList,
-                    buttonOnClick = { _, _ -> },
+                    buttonOnClick = { _ -> },
                 )
             }
         }

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddComposables.kt
@@ -47,6 +47,7 @@ import com.heyzeusv.yourlists.database.models.DefaultItem
 import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.util.EditItemBottomSheetContent
 import com.heyzeusv.yourlists.util.AddDestination
+import com.heyzeusv.yourlists.util.ListOptions
 import com.heyzeusv.yourlists.util.BottomSheet
 import com.heyzeusv.yourlists.util.FabState
 import com.heyzeusv.yourlists.util.ItemInfo
@@ -108,7 +109,7 @@ fun AddScreen(
     addToListOnClick: (DefaultItem) -> Unit,
     deleteDefaultItemOnClick: (DefaultItem) -> Unit,
     itemLists: List<ItemListWithItems>,
-    addListButtonOnClick: (ItemListWithItems, AddListOptions) -> Unit,
+    addListButtonOnClick: (ItemListWithItems, ListOptions) -> Unit,
 ) {
     val pagerState = rememberPagerState(pageCount = { 2 })
     val coroutineScope = rememberCoroutineScope()
@@ -327,7 +328,7 @@ fun AddListPage(
 @Composable
 fun AddListBottomSheetContent(
     itemList: ItemListWithItems,
-    buttonOnClick: (ItemListWithItems, AddListOptions) -> Unit,
+    buttonOnClick: (ItemListWithItems, ListOptions) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -340,14 +341,14 @@ fun AddListBottomSheetContent(
             style = MaterialTheme.typography.headlineMedium
         )
         Button(
-            onClick = { buttonOnClick(itemList, AddListOptions.ALL_AS_UNCHECKED) },
+            onClick = { buttonOnClick(itemList, ListOptions.COPY_ALL_AS_UNCHECKED) },
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.extraSmall,
         ) {
             Text(text = sRes(R.string.asbs_add_all_unchecked).uppercase())
         }
         Button(
-            onClick = { buttonOnClick(itemList, AddListOptions.ALL_AS_IS) },
+            onClick = { buttonOnClick(itemList, ListOptions.COPY_ALL_AS_IS) },
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.extraSmall,
             colors = ButtonDefaults.filledTonalButtonColors(
@@ -358,7 +359,7 @@ fun AddListBottomSheetContent(
             Text(text = sRes(R.string.asbs_add_all_as_is).uppercase())
         }
         OutlinedButton(
-            onClick = { buttonOnClick(itemList, AddListOptions.ONLY_UNCHECKED) },
+            onClick = { buttonOnClick(itemList, ListOptions.COPY_ONLY_UNCHECKED) },
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.extraSmall,
         ) {

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddListOptions.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddListOptions.kt
@@ -1,7 +1,0 @@
-package com.heyzeusv.yourlists.add
-
-enum class AddListOptions {
-    ALL_AS_UNCHECKED,
-    ALL_AS_IS,
-    ONLY_UNCHECKED,
-}

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddViewModel.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddViewModel.kt
@@ -9,6 +9,10 @@ import com.heyzeusv.yourlists.database.models.DefaultItem
 import com.heyzeusv.yourlists.database.models.Item
 import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.util.AddDestination
+import com.heyzeusv.yourlists.util.ListOptions
+import com.heyzeusv.yourlists.util.ListOptions.COPY_ALL_AS_IS
+import com.heyzeusv.yourlists.util.ListOptions.COPY_ALL_AS_UNCHECKED
+import com.heyzeusv.yourlists.util.ListOptions.COPY_ONLY_UNCHECKED
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -97,12 +101,13 @@ class AddViewModel @Inject constructor(
         viewModelScope.launch { repo.deleteDefaultItems(defaultItem) }
     }
 
-    fun addListWithOption(itemList: ItemListWithItems, option: AddListOptions) {
+    fun addListWithOption(itemList: ItemListWithItems, option: ListOptions) {
         viewModelScope.launch {
             val itemsToAdd: List<Item> = when (option) {
-                AddListOptions.ALL_AS_UNCHECKED -> itemList.items.map { it.copy(isChecked = false) }
-                AddListOptions.ALL_AS_IS -> itemList.items
-                AddListOptions.ONLY_UNCHECKED -> itemList.items.filter { !it.isChecked }
+                COPY_ALL_AS_UNCHECKED -> itemList.items.map { it.copy(isChecked = false) }
+                COPY_ALL_AS_IS -> itemList.items
+                COPY_ONLY_UNCHECKED -> itemList.items.filter { !it.isChecked }
+                else -> return@launch
             }
             val itemsToAddEdited = itemsToAdd.map {
                 it.copy(

--- a/app/src/main/java/com/heyzeusv/yourlists/add/AddViewModel.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/add/AddViewModel.kt
@@ -8,8 +8,7 @@ import com.heyzeusv.yourlists.database.models.Category
 import com.heyzeusv.yourlists.database.models.DefaultItem
 import com.heyzeusv.yourlists.database.models.Item
 import com.heyzeusv.yourlists.util.AddDestination
-import com.heyzeusv.yourlists.util.ListOptions
-import com.heyzeusv.yourlists.util.ListOptions.Copy.*
+import com.heyzeusv.yourlists.util.ListOptions.Copy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -98,13 +97,9 @@ class AddViewModel @Inject constructor(
         viewModelScope.launch { repo.deleteDefaultItems(defaultItem) }
     }
 
-    fun addListWithOption(option: ListOptions.Copy) {
+    fun addListWithOption(option: Copy) {
         viewModelScope.launch {
-            val itemsToAdd: List<Item> = when (option) {
-                is AllAsUnchecked -> option.itemList.items.map { it.copy(isChecked = false) }
-                is AllAsIs -> option.itemList.items
-                is OnlyUnchecked -> option.itemList.items.filter { !it.isChecked }
-            }
+            val itemsToAdd: List<Item> = option.copyItems()
             val itemsToAddEdited = itemsToAdd.map {
                 it.copy(
                     itemId = 0L,

--- a/app/src/main/java/com/heyzeusv/yourlists/database/Repository.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/database/Repository.kt
@@ -31,6 +31,8 @@ interface Repository {
 
     suspend fun deleteItemList(vararg itemLists: ItemList)
 
+    suspend fun copyItemListWithItems(itemList: ItemList, items: List<Item>)
+
     fun getItemListWithId(id: Long): Flow<ItemList>
 
     fun getSortedItemListsWithItems(filter: OverviewFilter): Flow<List<ItemListWithItems>>

--- a/app/src/main/java/com/heyzeusv/yourlists/database/RepositoryImpl.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/database/RepositoryImpl.kt
@@ -64,6 +64,12 @@ class RepositoryImpl @Inject constructor(
     override suspend fun deleteItemList(vararg itemLists: ItemList) =
         withContext(Dispatchers.IO) { itemListDao.delete(*itemLists) }
 
+    override suspend fun copyItemListWithItems(itemList: ItemList, items: List<Item>) =
+        withContext(Dispatchers.IO) {
+            itemListDao.insert(itemList)
+            itemDao.insert(*items.toTypedArray())
+        }
+
     override fun getItemListWithId(id: Long): Flow<ItemList> = itemListDao.getItemListWithId(id)
 
     override fun getSortedItemListsWithItems(filter: OverviewFilter): Flow<List<ItemListWithItems>> =

--- a/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewBottomSheetActions.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewBottomSheetActions.kt
@@ -28,6 +28,24 @@ enum class OverviewBottomSheetActions(
         iconCdescId = R.string.osbs_cdesc_copy,
         iconSize = 20.dp,
     ),
+    COPY_AS_UNCHECKED(
+        nameId = R.string.osbs_copy_as_unchecked,
+        iconId = R.drawable.icon_blank,
+        iconCdescId = R.string.osbs_cdesc_copy_as_unchecked,
+        iconSize = 28.dp,
+    ),
+    COPY_AS_IS(
+        nameId = R.string.osbs_copy_as_is,
+        iconId = R.drawable.icon_blank,
+        iconCdescId = R.string.osbs_cdesc_copy_as_is,
+        iconSize = 28.dp,
+    ),
+    COPY_ONLY_UNCHECKED(
+        nameId = R.string.osbs_copy_only_unchecked,
+        iconId = R.drawable.icon_blank,
+        iconCdescId = R.string.osbs_cdesc_copy_only_unchecked,
+        iconSize = 28.dp,
+    ),
     DELETE(
         nameId = R.string.osbs_delete,
         iconId = R.drawable.icon_delete,

--- a/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
@@ -6,6 +6,9 @@ import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -56,7 +59,7 @@ import com.heyzeusv.yourlists.util.FilterAlertDialog
 import com.heyzeusv.yourlists.util.InputAlertDialog
 import com.heyzeusv.yourlists.util.ListInfo
 import com.heyzeusv.yourlists.util.ListOptions
-import com.heyzeusv.yourlists.util.ListOptions.Copy
+import com.heyzeusv.yourlists.util.ListOptions.Copy.*
 import com.heyzeusv.yourlists.util.ListOptions.Delete
 import com.heyzeusv.yourlists.util.ListOptions.Rename
 import com.heyzeusv.yourlists.util.OverviewDestination
@@ -253,8 +256,7 @@ fun OverviewScreen(
                 updateShowBottomSheet(false)
             },
             copyOnClick = {
-                // TODO: Implement dropdown showing options
-                listOptionOnClick(Copy.OnlyUnchecked(selectedItemList))
+                listOptionOnClick(it)
                 updateShowBottomSheet(false)
             },
             deleteOnClick = {
@@ -303,7 +305,7 @@ fun OverviewFilter(
 fun OverviewBottomSheetContent(
     itemList: ItemListWithItems,
     renameOnClick: () -> Unit,
-    copyOnClick: () -> Unit,
+    copyOnClick: (ListOptions) -> Unit,
     deleteOnClick: () -> Unit,
 ) {
     Column(
@@ -321,14 +323,52 @@ fun OverviewBottomSheetContent(
             action = OverviewBottomSheetActions.RENAME,
             actionOnClick = renameOnClick,
         )
-        OverviewBottomSheetAction(
-            action = OverviewBottomSheetActions.COPY,
-            actionOnClick = copyOnClick,
+        OverviewCopyListAction(
+            itemList = itemList,
+            copyOptionOnClick = copyOnClick,
         )
         OverviewBottomSheetAction(
             action = OverviewBottomSheetActions.DELETE,
             actionOnClick = deleteOnClick,
         )
+    }
+}
+
+@Composable
+fun OverviewCopyListAction(
+    itemList: ItemListWithItems,
+    copyOptionOnClick: (ListOptions) -> Unit,
+) {
+    var showCopyOptions by remember { mutableStateOf(false) }
+    // TODO: Add arrow up/down icon to show user there are options
+    Column(modifier = Modifier.fillMaxWidth()) {
+        OverviewBottomSheetAction(
+            action = OverviewBottomSheetActions.COPY,
+            actionOnClick = { showCopyOptions = !showCopyOptions },
+        )
+        AnimatedVisibility(
+            visible = showCopyOptions,
+            enter = expandVertically(),
+            exit = shrinkVertically(),
+        ) {
+            Column(
+                modifier = Modifier.padding(top = dRes(R.dimen.bs_vertical_spacedBy)),
+                verticalArrangement = Arrangement.spacedBy(dRes(R.dimen.bs_vertical_spacedBy)),
+            ) {
+                OverviewBottomSheetAction(
+                    action = OverviewBottomSheetActions.COPY_AS_UNCHECKED,
+                    actionOnClick = { copyOptionOnClick(AllAsUnchecked(itemList)) },
+                )
+                OverviewBottomSheetAction(
+                    action = OverviewBottomSheetActions.COPY_AS_IS,
+                    actionOnClick = { copyOptionOnClick(AllAsIs(itemList)) },
+                )
+                OverviewBottomSheetAction(
+                    action = OverviewBottomSheetActions.COPY_ONLY_UNCHECKED,
+                    actionOnClick = { copyOptionOnClick(OnlyUnchecked(itemList)) },
+                )
+            }
+        }
     }
 }
 
@@ -469,7 +509,7 @@ fun PortationProgress(portationStatus: PortationStatus) {
             modifier = Modifier
                 .fillMaxSize()
                 .background(BlackAlpha90)
-                .clickable(enabled = false) {  },
+                .clickable(enabled = false) { },
             contentAlignment = Alignment.Center,
         ) {
             Column(

--- a/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
@@ -26,8 +26,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -45,7 +43,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.Hyphens
 import androidx.compose.ui.text.style.LineBreak
@@ -56,6 +53,7 @@ import androidx.navigation.NavHostController
 import com.heyzeusv.yourlists.R
 import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.ui.theme.BlackAlpha90
+import com.heyzeusv.yourlists.util.ArrowVerticalFlip
 import com.heyzeusv.yourlists.util.BottomSheet
 import com.heyzeusv.yourlists.util.DrawerOnClicks
 import com.heyzeusv.yourlists.util.EmptyList
@@ -358,12 +356,9 @@ fun OverviewCopyListAction(
                 actionOnClick = { showCopyOptions = !showCopyOptions },
                 modifier = Modifier.align(Alignment.CenterStart),
             )
-            Icon(
-                imageVector = Icons.Filled.ArrowDropDown,
-                contentDescription = sRes(R.string.osbs_cdesc_copy_show),
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .rotate(if (showCopyOptions) 180f else 0f),
+            ArrowVerticalFlip(
+                trigger = showCopyOptions,
+                modifier = Modifier.align(Alignment.CenterEnd)
             )
         }
         AnimatedVisibility(

--- a/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewComposables.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -43,7 +45,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.Hyphens
+import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -59,7 +64,9 @@ import com.heyzeusv.yourlists.util.FilterAlertDialog
 import com.heyzeusv.yourlists.util.InputAlertDialog
 import com.heyzeusv.yourlists.util.ListInfo
 import com.heyzeusv.yourlists.util.ListOptions
-import com.heyzeusv.yourlists.util.ListOptions.Copy.*
+import com.heyzeusv.yourlists.util.ListOptions.Copy.AllAsIs
+import com.heyzeusv.yourlists.util.ListOptions.Copy.AllAsUnchecked
+import com.heyzeusv.yourlists.util.ListOptions.Copy.OnlyUnchecked
 import com.heyzeusv.yourlists.util.ListOptions.Delete
 import com.heyzeusv.yourlists.util.ListOptions.Rename
 import com.heyzeusv.yourlists.util.OverviewDestination
@@ -246,6 +253,7 @@ fun OverviewScreen(
         )
     }
     BottomSheet(
+        modifier = Modifier.height(dRes(R.dimen.osbs_height)),
         isVisible = showBottomSheet,
         updateIsVisible = { updateShowBottomSheet(it) },
     ) {
@@ -310,14 +318,17 @@ fun OverviewBottomSheetContent(
 ) {
     Column(
         modifier = Modifier
-            .padding(bottom = dRes(R.dimen.osbs_padding_bottom))
             .padding(all = dRes(R.dimen.bs_padding_all))
             .fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(dRes(R.dimen.bs_vertical_spacedBy)),
     ) {
         Text(
             text = sRes(R.string.osbs_manage, itemList.itemList.name),
-            style = MaterialTheme.typography.headlineMedium
+            maxLines = 2,
+            style = MaterialTheme.typography.headlineMedium.copy(
+                lineBreak = LineBreak.Paragraph,
+                hyphens = Hyphens.Auto,
+            ),
         )
         OverviewBottomSheetAction(
             action = OverviewBottomSheetActions.RENAME,
@@ -340,12 +351,21 @@ fun OverviewCopyListAction(
     copyOptionOnClick: (ListOptions) -> Unit,
 ) {
     var showCopyOptions by remember { mutableStateOf(false) }
-    // TODO: Add arrow up/down icon to show user there are options
-    Column(modifier = Modifier.fillMaxWidth()) {
-        OverviewBottomSheetAction(
-            action = OverviewBottomSheetActions.COPY,
-            actionOnClick = { showCopyOptions = !showCopyOptions },
-        )
+    Column {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            OverviewBottomSheetAction(
+                action = OverviewBottomSheetActions.COPY,
+                actionOnClick = { showCopyOptions = !showCopyOptions },
+                modifier = Modifier.align(Alignment.CenterStart),
+            )
+            Icon(
+                imageVector = Icons.Filled.ArrowDropDown,
+                contentDescription = sRes(R.string.osbs_cdesc_copy_show),
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .rotate(if (showCopyOptions) 180f else 0f),
+            )
+        }
         AnimatedVisibility(
             visible = showCopyOptions,
             enter = expandVertically(),
@@ -376,24 +396,25 @@ fun OverviewCopyListAction(
 fun OverviewBottomSheetAction(
     action: OverviewBottomSheetActions,
     actionOnClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clickable { actionOnClick() },
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(dRes(R.dimen.bs_horizontal_spacedBy))
+        horizontalArrangement = Arrangement.spacedBy(dRes(R.dimen.bs_horizontal_spacedBy)),
     ) {
         Icon(
             painter = pRes(action.iconId),
             contentDescription = sRes(action.iconCdescId),
             modifier = Modifier.height(action.iconSize),
-            tint = action.color
+            tint = action.color,
         )
         Text(
             text = sRes(action.nameId),
             color = action.color,
-            style = MaterialTheme.typography.titleLarge
+            style = MaterialTheme.typography.titleLarge,
         )
     }
 }
@@ -592,6 +613,21 @@ private fun OverviewBottomSheetPreview() {
                     renameOnClick = { },
                     copyOnClick = { },
                     deleteOnClick = { },
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OverviewCopyListActionPreview() {
+    PreviewUtil.run {
+        Preview {
+            Surface(modifier = Modifier.fillMaxWidth()) {
+                OverviewCopyListAction(
+                    itemList = ItemListWithItems(),
+                    copyOptionOnClick = { }
                 )
             }
         }

--- a/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewViewModel.kt
@@ -14,7 +14,6 @@ import com.heyzeusv.yourlists.di.IODispatcher
 import com.heyzeusv.yourlists.overview.OverviewFilterNames.BY_COMPLETION
 import com.heyzeusv.yourlists.util.ListOptions
 import com.heyzeusv.yourlists.util.ListOptions.Copy
-import com.heyzeusv.yourlists.util.ListOptions.Copy.*
 import com.heyzeusv.yourlists.util.ListOptions.Delete
 import com.heyzeusv.yourlists.util.ListOptions.Rename
 import com.heyzeusv.yourlists.util.portation.PortationStatus
@@ -128,12 +127,7 @@ class OverviewViewModel @Inject constructor(
             itemListId = nextItemListId.value,
             name = copyName.take(32)
         )
-        // TODO: Maybe make this in extension function since it is used in AddViewModel as well
-        val copyItems: List<Item> = when (copyOption) {
-            is AllAsUnchecked -> copyOption.itemList.items.map { it.copy(isChecked = false) }
-            is AllAsIs -> copyOption.itemList.items
-            is OnlyUnchecked -> copyOption.itemList.items.filter { !it.isChecked }
-        }
+        val copyItems: List<Item> = copyOption.copyItems()
         val copyItemsEdited = copyItems.map {
             it.copy(
                 itemId = 0L,

--- a/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/overview/OverviewViewModel.kt
@@ -10,9 +10,13 @@ import com.heyzeusv.yourlists.database.Database
 import com.heyzeusv.yourlists.database.Repository
 import com.heyzeusv.yourlists.database.models.Item
 import com.heyzeusv.yourlists.database.models.ItemList
-import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.di.IODispatcher
 import com.heyzeusv.yourlists.overview.OverviewFilterNames.BY_COMPLETION
+import com.heyzeusv.yourlists.util.ListOptions
+import com.heyzeusv.yourlists.util.ListOptions.Copy
+import com.heyzeusv.yourlists.util.ListOptions.Copy.*
+import com.heyzeusv.yourlists.util.ListOptions.Delete
+import com.heyzeusv.yourlists.util.ListOptions.Rename
 import com.heyzeusv.yourlists.util.portation.PortationStatus
 import com.heyzeusv.yourlists.util.portation.PortationStatus.Error
 import com.heyzeusv.yourlists.util.portation.PortationStatus.Progress
@@ -97,46 +101,50 @@ class OverviewViewModel @Inject constructor(
         settingsManager.updatePortationPath(path)
     }
 
-    fun renameItemList(itemList: ItemList, newName: String) {
-        viewModelScope.launch {
-            val renamed = itemList.copy(name = newName)
-            repo.updateItemList(renamed)
-        }
-    }
-
     fun insertItemList(name: String) {
         viewModelScope.launch {
             repo.insertItemList(ItemList(nextItemListId.value, name))
         }
     }
 
-    fun copyItemList(itemList: ItemListWithItems) {
+    fun handleListOption(option: ListOptions) {
         viewModelScope.launch {
-            val copyName = "${itemList.itemList.name} - Copy"
-            val copyItemList = itemList.itemList.copy(
-                itemListId = nextItemListId.value,
-                name = copyName.take(32)
-            )
-            val copyItems = mutableListOf<Item>()
-            itemList.items.forEach {
-                copyItems.add(
-                    it.copy(
-                        itemId = 0L,
-                        parentItemListId = nextItemListId.value
-                    )
-                )
+            when (option) {
+                is Rename -> renameItemList(option.itemList.itemList, option.newName)
+                is Copy -> copyItemList(option)
+                is Delete -> deleteItemList(option.itemList.itemList)
             }
-
-            repo.insertItemList(copyItemList)
-            repo.insertItems(*copyItems.toTypedArray())
         }
     }
 
-    fun deleteItemList(itemList: ItemList) {
-        viewModelScope.launch {
-            repo.deleteItemList(itemList)
-        }
+    private suspend fun renameItemList(itemList: ItemList, newName: String) {
+        val renamed = itemList.copy(name = newName)
+        repo.updateItemList(renamed)
     }
+
+    private suspend fun copyItemList(copyOption: Copy) {
+        val copyName = "${copyOption.itemList.itemList.name} - Copy"
+        val copyItemList = copyOption.itemList.itemList.copy(
+            itemListId = nextItemListId.value,
+            name = copyName.take(32)
+        )
+        // TODO: Maybe make this in extension function since it is used in AddViewModel as well
+        val copyItems: List<Item> = when (copyOption) {
+            is AllAsUnchecked -> copyOption.itemList.items.map { it.copy(isChecked = false) }
+            is AllAsIs -> copyOption.itemList.items
+            is OnlyUnchecked -> copyOption.itemList.items.filter { !it.isChecked }
+        }
+        val copyItemsEdited = copyItems.map {
+            it.copy(
+                itemId = 0L,
+                parentItemListId = nextItemListId.value
+            )
+        }
+
+        repo.copyItemListWithItems(copyItemList, copyItemsEdited)
+    }
+
+    private suspend fun deleteItemList(itemList: ItemList) = repo.deleteItemList(itemList)
 
     fun importCsvToDatabase(selectedDirectoryUri: Uri) {
         viewModelScope.launch(ioDispatcher) {

--- a/app/src/main/java/com/heyzeusv/yourlists/util/ExtensionFunctions.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/ExtensionFunctions.kt
@@ -1,77 +1,13 @@
 package com.heyzeusv.yourlists.util
 
-import androidx.annotation.ArrayRes
-import androidx.annotation.DimenRes
-import androidx.annotation.DrawableRes
-import androidx.annotation.IntegerRes
-import androidx.annotation.StringRes
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.integerResource
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringArrayResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.unit.Dp
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
-
-/**
- *  Load a string resource with formatting.
- *
- *  @param id The resource identifier.
- *  @param args The format arguments.
- *  @return The string data associated with the resource.
- */
-@Composable
-@ReadOnlyComposable
-fun sRes(@StringRes id: Int, vararg args: Any): String = stringResource(id, *args)
-
-/**
- *  Load a string array resource .
- *
- *  @param id The resource identifier.
- *  @return The string array data associated with the resource.
- */
-@Composable
-@ReadOnlyComposable
-fun saRes(@ArrayRes id: Int): Array<String> = stringArrayResource(id)
-
-/**
- *  Create a [Painter] from an Android resource id.
- *
- *  @param id Resources object to query the image file from.
- *  @return [Painter] used for drawing the loaded resource.
- */
-@Composable
-fun pRes(@DrawableRes id: Int): Painter = painterResource(id)
-
-/**
- *  Load a dimension resource.
- *
- *  @param id The resource identifier.
- *  @return The dimension value associated with the resource.
- */
-@Composable
-@ReadOnlyComposable
-fun dRes(@DimenRes id: Int): Dp = dimensionResource(id)
-
-/**
- *  Load a integer resource.
- *
- *  @param id The resource identifier.
- *  @return The integer value associated with the resource.
- */
-@Composable
-@ReadOnlyComposable
-fun iRes(@IntegerRes id: Int): Int = integerResource(id)
 
 /**
  *  Navigates app to given route.

--- a/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
@@ -1,5 +1,10 @@
 package com.heyzeusv.yourlists.util
 
+import androidx.annotation.ArrayRes
+import androidx.annotation.DimenRes
+import androidx.annotation.DrawableRes
+import androidx.annotation.IntegerRes
+import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
@@ -53,6 +58,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -64,14 +70,21 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.integerResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import com.heyzeusv.yourlists.R
 import com.heyzeusv.yourlists.database.models.BaseItem
 import com.heyzeusv.yourlists.database.models.Category
@@ -79,6 +92,56 @@ import com.heyzeusv.yourlists.database.models.Item
 import com.heyzeusv.yourlists.database.models.ItemListWithItems
 import com.heyzeusv.yourlists.ui.theme.BlackAlpha60
 import java.text.DecimalFormat
+
+/**
+ *  Load a string resource with formatting.
+ *
+ *  @param id The resource identifier.
+ *  @param args The format arguments.
+ *  @return The string data associated with the resource.
+ */
+@Composable
+@ReadOnlyComposable
+fun sRes(@StringRes id: Int, vararg args: Any): String = stringResource(id, *args)
+
+/**
+ *  Load a string array resource .
+ *
+ *  @param id The resource identifier.
+ *  @return The string array data associated with the resource.
+ */
+@Composable
+@ReadOnlyComposable
+fun saRes(@ArrayRes id: Int): Array<String> = stringArrayResource(id)
+
+/**
+ *  Create a [Painter] from an Android resource id.
+ *
+ *  @param id Resources object to query the image file from.
+ *  @return [Painter] used for drawing the loaded resource.
+ */
+@Composable
+fun pRes(@DrawableRes id: Int): Painter = painterResource(id)
+
+/**
+ *  Load a dimension resource.
+ *
+ *  @param id The resource identifier.
+ *  @return The dimension value associated with the resource.
+ */
+@Composable
+@ReadOnlyComposable
+fun dRes(@DimenRes id: Int): Dp = dimensionResource(id)
+
+/**
+ *  Load a integer resource.
+ *
+ *  @param id The resource identifier.
+ *  @return The integer value associated with the resource.
+ */
+@Composable
+@ReadOnlyComposable
+fun iRes(@IntegerRes id: Int): Int = integerResource(id)
 
 @Composable
 fun EmptyList(

--- a/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
@@ -283,6 +283,7 @@ fun TextFieldWithLimit(
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun BottomSheet(
+    modifier: Modifier = Modifier,
     isVisible: Boolean,
     updateIsVisible: (Boolean) -> Unit,
     content: @Composable () -> Unit,
@@ -313,7 +314,7 @@ fun BottomSheet(
             contentAlignment = Alignment.BottomCenter,
         ) {
             Card(
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxWidth()
                     .offset(y = dRes(R.dimen.bs_bottom_spacer))
                     .animateEnterExit(

--- a/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
@@ -42,7 +42,6 @@ import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
@@ -55,6 +54,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -541,7 +541,7 @@ fun FilteredDropDownMenu(
                 .onFocusChanged { expanded = it.isFocused }
                 .menuAnchor(),
             label = { Text(label) },
-            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            trailingIcon = { ArrowVerticalFlip(trigger = expanded) },
             supportingText = {
                 Row {
                     Text(
@@ -586,7 +586,7 @@ fun ArrowVerticalFlip(
     trigger: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    var rotation by remember { mutableStateOf(0f) }
+    var rotation by remember { mutableFloatStateOf(0f) }
     LaunchedEffect(key1 = trigger) {
         animate(
             initialValue = if (trigger) 0f else 180f,

--- a/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/GeneralComposables.kt
@@ -4,6 +4,9 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -30,6 +33,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -49,12 +53,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.StrokeCap
@@ -573,6 +579,29 @@ fun FilteredDropDownMenu(
             }
         }
     }
+}
+
+@Composable
+fun ArrowVerticalFlip(
+    trigger: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    var rotation by remember { mutableStateOf(0f) }
+    LaunchedEffect(key1 = trigger) {
+        animate(
+            initialValue = if (trigger) 0f else 180f,
+            targetValue = if (trigger) 180f else 0f,
+            animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
+        ) { value, _ ->
+            rotation = value
+        }
+    }
+
+    Icon(
+        imageVector = Icons.Filled.ArrowDropDown,
+        contentDescription = sRes(R.string.arrow_flip_cdesc),
+        modifier = modifier.rotate(rotation),
+    )
 }
 
 @Preview

--- a/app/src/main/java/com/heyzeusv/yourlists/util/ListOptions.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/ListOptions.kt
@@ -1,0 +1,9 @@
+package com.heyzeusv.yourlists.util
+
+enum class ListOptions {
+    RENAME,
+    COPY_ALL_AS_UNCHECKED,
+    COPY_ALL_AS_IS,
+    COPY_ONLY_UNCHECKED,
+    DELETE,
+}

--- a/app/src/main/java/com/heyzeusv/yourlists/util/ListOptions.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/ListOptions.kt
@@ -1,5 +1,6 @@
 package com.heyzeusv.yourlists.util
 
+import com.heyzeusv.yourlists.database.models.Item
 import com.heyzeusv.yourlists.database.models.ItemListWithItems
 
 sealed class ListOptions {
@@ -10,6 +11,14 @@ sealed class ListOptions {
         data class AllAsUnchecked(override val itemList: ItemListWithItems): Copy()
         data class AllAsIs(override val itemList: ItemListWithItems): Copy()
         data class OnlyUnchecked(override val itemList: ItemListWithItems): Copy()
+
+        fun copyItems(): List<Item> {
+            return when (this) {
+                is AllAsUnchecked -> itemList.items.map { it.copy(isChecked = false) }
+                is AllAsIs -> itemList.items
+                is OnlyUnchecked -> itemList.items.filter { !it.isChecked }
+            }
+        }
     }
     data class Delete(override val itemList: ItemListWithItems): ListOptions()
 }

--- a/app/src/main/java/com/heyzeusv/yourlists/util/ListOptions.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/ListOptions.kt
@@ -1,9 +1,15 @@
 package com.heyzeusv.yourlists.util
 
-enum class ListOptions {
-    RENAME,
-    COPY_ALL_AS_UNCHECKED,
-    COPY_ALL_AS_IS,
-    COPY_ONLY_UNCHECKED,
-    DELETE,
+import com.heyzeusv.yourlists.database.models.ItemListWithItems
+
+sealed class ListOptions {
+    abstract val itemList: ItemListWithItems
+
+    data class Rename(override val itemList: ItemListWithItems, val newName: String): ListOptions()
+    sealed class Copy: ListOptions() {
+        data class AllAsUnchecked(override val itemList: ItemListWithItems): Copy()
+        data class AllAsIs(override val itemList: ItemListWithItems): Copy()
+        data class OnlyUnchecked(override val itemList: ItemListWithItems): Copy()
+    }
+    data class Delete(override val itemList: ItemListWithItems): ListOptions()
 }

--- a/app/src/main/java/com/heyzeusv/yourlists/util/PreviewUtil.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/PreviewUtil.kt
@@ -39,13 +39,26 @@ object PreviewUtil {
     )
     val halfCheckedItemList = ItemListWithItems(
         itemList = ItemList(0L, "Half Checked / Half UnChecked Item List"),
-        items = List(10) { if (it % 2 == 0) itemChecked else itemUnchecked }
+        items = List(10) {
+            if (it % 2 == 0) {
+                itemChecked.copy(itemId = it.toLong())
+            } else {
+                itemUnchecked.copy(itemId = it.toLong())
+            }
+        }
     )
     val emptyItemList = ItemListWithItems(
         itemList = ItemList(0L, "Empty List"),
         items = emptyList()
     )
-    val itemLists = List(10) { if (it % 2 == 0) halfCheckedItemList else emptyItemList }
+    val itemLists = List(10) {
+        if (it % 2 == 0) {
+            halfCheckedItemList.copy(
+                itemList = halfCheckedItemList.itemList.copy(itemListId = it.toLong())
+            )
+        } else
+            emptyItemList.copy(itemList = emptyItemList.itemList.copy(itemListId = it.toLong()))
+    }
     val defaultItem = DefaultItem(
         itemId = 0L,
         name = "DefaultItem DefaultItem DefaultItem DefaultItem DefaultItem",
@@ -54,7 +67,7 @@ object PreviewUtil {
         unit = "Unit",
         memo = "This is a default item",
         )
-    val defaultItemList = List(10) { defaultItem }
+    val defaultItemList = List(10) { defaultItem.copy(itemId = it.toLong()) }
 
     @Composable
     fun Preview(content: @Composable () -> Unit) {

--- a/app/src/main/res/drawable/icon_blank.xml
+++ b/app/src/main/res/drawable/icon_blank.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="@android:color/transparent"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M16,9v10H8V9h8m-1.5,-6h-5l-1,1H5v2h14V4h-3.5l-1,-1zM18,7H6v12c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7z" />
+</vector>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -59,7 +59,7 @@
     <dimen name="os_lists_padding_all">8.dp</dimen>
     <dimen name="os_lists_spacedBy">12.dp</dimen>
     <!-- OverviewScreen.BottomSheet (osbs) -->
-    <dimen name="osbs_padding_bottom">100.dp</dimen>
+    <dimen name="osbs_height">375.dp</dimen>
     <!-- OverviewScreen.ListInfo (osli) -->
     <dimen name="osli_options_padding_top">5.dp</dimen>
     <dimen name="osli_padding_all">12.dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="osbs_cdesc_rename">Rename this list.</string>
     <string name="osbs_copy">Copy</string>
     <string name="osbs_cdesc_copy">Create a copy of this list.</string>
+    <string name="osbs_cdesc_copy_show">Show copy options.</string>
     <string name="osbs_copy_as_unchecked">As unchecked</string>
     <string name="osbs_cdesc_copy_as_unchecked">Create a copy of this list with all items unchecked.</string>
     <string name="osbs_copy_as_is">As is</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,12 @@
     <string name="osbs_cdesc_rename">Rename this list.</string>
     <string name="osbs_copy">Copy</string>
     <string name="osbs_cdesc_copy">Create a copy of this list.</string>
+    <string name="osbs_copy_as_unchecked">As unchecked</string>
+    <string name="osbs_cdesc_copy_as_unchecked">Create a copy of this list with all items unchecked.</string>
+    <string name="osbs_copy_as_is">As is</string>
+    <string name="osbs_cdesc_copy_as_is">Create a copy of this list with all items having the same checked status as this list.</string>
+    <string name="osbs_copy_only_unchecked">Only unchecked</string>
+    <string name="osbs_cdesc_copy_only_unchecked">Create a copy of this list with only unchecked items of this list</string>
     <string name="osbs_delete">Delete</string>
     <string name="osbs_cdesc_delete">Delete this list.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="open_drawer">Open Drawer</string>
     <string name="button_cdesc_options">Displays additional options</string>
     <string name="blank_string" />
+    <string name="arrow_flip_cdesc">Show options.</string>
     <string-array name="unit_values">
         <item>Unit</item>
         <item>lb</item>
@@ -76,7 +77,6 @@
     <string name="osbs_cdesc_rename">Rename this list.</string>
     <string name="osbs_copy">Copy</string>
     <string name="osbs_cdesc_copy">Create a copy of this list.</string>
-    <string name="osbs_cdesc_copy_show">Show copy options.</string>
     <string name="osbs_copy_as_unchecked">As unchecked</string>
     <string name="osbs_cdesc_copy_as_unchecked">Create a copy of this list with all items unchecked.</string>
     <string name="osbs_copy_as_is">As is</string>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,7 +5,7 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
+        <!--
         <include .../>
         <exclude .../>
         -->


### PR DESCRIPTION
Added the same list copy options on Add screen to Overview screen. Meaning that users can now copy a list with the following options:

1. Copy all items as unchecked
2. Copy all items as is
3. Copy only unchecked items