### PR TITLE
v2.2.1 Bugfix: Remove filter icon from Add screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,8 +33,8 @@ android {
         applicationId = "com.heyzeusv.yourlists"
         minSdk = 24
         targetSdk = 34
-        versionCode = 7
-        versionName = "2.2.0"
+        versionCode = 8
+        versionName = "2.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/heyzeusv/yourlists/util/ExtensionFunctions.kt
+++ b/app/src/main/java/com/heyzeusv/yourlists/util/ExtensionFunctions.kt
@@ -54,7 +54,7 @@ fun NavHostController.navigateToAdd(listId: Long) {
  */
 fun NavBackStackEntry?.currentDestination(): Destination {
     return Destinations.find {
-        this?.destination?.route?.contains(it.route) ?: false
+        this?.destination?.route?.split("/")?.first() == it.route
     } ?: OverviewDestination
 }
 


### PR DESCRIPTION
Add screen was displaying Filter icon on TopAppBar, which was clickable, but didn't do anything. This was due to AddDestination route being "add/{listId}" which currentDestination() was matching to ListDestination route because ListDestination was listed before AddDestination in Destinations list.

Fixed by having currentDestination only check the route before the forward-slash ('/').